### PR TITLE
Fix wrong magic packet transfer

### DIFF
--- a/src/Network/WoL.hs
+++ b/src/Network/WoL.hs
@@ -18,9 +18,10 @@ module Network.WoL
 
 import Network.MacAddress
 
-import Data.Char
+import qualified Data.ByteString as BS
 import Network.BSD
-import Network.Socket hiding (send)
+import Network.Socket hiding (send, sendTo, recv, recvFrom)
+import Network.Socket.ByteString hiding (send)
 
 -- | User friendly wrapper around `send` function.
 sendWoLMagicPacket :: String -> String -> Int -> IO ()
@@ -36,15 +37,15 @@ send host addr port = do
   s <- socket AF_INET Datagram udp
   setSocketOption s Broadcast 1
   let sockAddr = SockAddrInet port host
-  Network.Socket.sendTo s (magicPacket addr) sockAddr
+  sendTo s (magicPacket addr) sockAddr
   sClose s
 
 -- | Construct a magic packet based on `MacAddress`.
-magicPacket :: MacAddress -> String
+magicPacket :: MacAddress -> BS.ByteString
 magicPacket addr =
-  let prefix = replicate 6 '\255'
-      addr'  = map (chr . fromIntegral) (bytes addr)
-  in prefix ++ concat (replicate 16 addr')
+  let prefix = replicate 6 $ fromIntegral 255
+      addr'  = bytes addr
+  in BS.pack $ prefix ++ concat (replicate 16 addr')
 
 udp :: ProtocolNumber
 udp = 17

--- a/wol.cabal
+++ b/wol.cabal
@@ -1,5 +1,5 @@
 name:                wol
-version:             0.1.2
+version:             0.1.3
 synopsis:            Send a Wake on LAN Magic Packet
 description:         A program and library to a send WoL Magic Packet, to
                      remotely start a computer.

--- a/wol.cabal
+++ b/wol.cabal
@@ -37,8 +37,9 @@ executable wol
 
 library
   build-depends:     base >= 3 && < 5,
-                     network >= 2.3 && < 2.4,
-                     split >= 0.1.1 && < 0.2
+                     network,
+                     split,
+                     bytestring
   hs-source-dirs:    src
   exposed-modules:   Network.WoL
                      Network.MacAddress


### PR DESCRIPTION
Hi,

sendTo of Network.Socket is not working properly with Word8, so wrong magic packets are transfered.
This PR replaces sendTo with Network.Socket.ByteString's one.
