### PR TITLE
sClose (imported from Network.Socket) is deprecated,

### DIFF
--- a/src/Network/WoL.hs
+++ b/src/Network/WoL.hs
@@ -38,7 +38,7 @@ send host addr port = do
   setSocketOption s Broadcast 1
   let sockAddr = SockAddrInet port host
   sendTo s (magicPacket addr) sockAddr
-  sClose s
+  close s
 
 -- | Construct a magic packet based on `MacAddress`.
 magicPacket :: MacAddress -> BS.ByteString


### PR DESCRIPTION
Using close is suggested.
Build has been made by using stack, resolver: lts-7.17, ghc-8.0.1
.